### PR TITLE
Update password decode command

### DIFF
--- a/stable/jenkins/templates/NOTES.txt
+++ b/stable/jenkins/templates/NOTES.txt
@@ -1,5 +1,5 @@
 1. Get your '{{ .Values.Master.AdminUser }}' user password by running:
-  printf $(printf '\%o' `kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.jenkins-admin-password[*]}"`);echo
+  echo $(kubectl get secret --namespace default jenkins-jenkins -o jsonpath="{.data.jenkins-admin-password}") | openssl base64 -d
 
 2. Get the Jenkins URL to visit by running these commands in the same shell:
 {{- if contains "NodePort" .Values.Master.ServiceType }}


### PR DESCRIPTION
The `printf` command did not work for me on Debian / Bash. This PR suggests an alternative command that uses `openssl` which is by default installed on OSX and very common in all Linux distros.

We could also use `base64 --decode` but I believe that this is not by default available on OSX